### PR TITLE
Allow decoration of skyline objects

### DIFF
--- a/lib/skyline/engine.rb
+++ b/lib/skyline/engine.rb
@@ -71,6 +71,14 @@ module Skyline
         app.config.skyline_plugins_manager.load_all!
       end      
     end
-    
+
+    # Enable decoration of Skyline objects
+    # http://guides.rubyonrails.org/engines.html#overriding-models-and-controllers
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator.rb").each do |c|
+        require_dependency(c)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
To allow granular extending this callback is added. Before this change it was only possible to overwrite the complete class (by rails autoloading mechanisms).

I needed this ability to be able to add custom callback handlers:

```
# app/decorators/articles_controller_decorator.rb
Skyline::ArticlesController.set_callback :authenticate,
  :after,
  lambda { Rails.logger "Santa is logging in!" },
  :if => lambda {|c| current_user.name == "Santa" }
```
